### PR TITLE
giCart should show total quantity not just item count

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Best served as a component of [gi](https://github.com/goincremental/gi) but if y
 - Client side components: `bower install gi-commerce`
 
 ##Release Notes
+v0.6.1
+- Summary directive now displays total quantity of items, not just number of distinct items
+
 v0.6.0
 - added giPaymentThanks directive allowing the application to inject their own thankyou directive.
 - To achieve this giCart has become a provider, exposing a setThankyouDirective function which accepts a string which will be used to create an element (so typically you'll use the name of your custom directive that you want injecting on the thankyou page)

--- a/client/services/cart.coffee
+++ b/client/services/cart.coffee
@@ -180,6 +180,13 @@ angular.module('gi.commerce').provider 'giCart', () ->
       totalItems: () ->
         cart.items.length
 
+      totalQuantity: () ->
+        result = 0
+        angular.forEach cart.items, (item) ->
+          result += item._quantity
+
+        result
+
       totalCost:  () ->
         getSubTotal() + getTaxTotal()
 
@@ -192,7 +199,7 @@ angular.module('gi.commerce').provider 'giCart', () ->
         $window.history.back()
 
       checkAccount: () ->
-        if not @customer
+        if @customerInfo and (not @customer)
           $rootScope.$broadcast('giCart:accountRequired', @customerInfo)
         cart.stage += 1
 

--- a/client/views/gi.commerce.summary.html
+++ b/client/views/gi.commerce.summary.html
@@ -3,6 +3,6 @@
     <span class="fa fa-shopping-cart fa-lg"></span>
   </div>
   <div class="col-xs-7">
-    <span class="badge">{{ giCart.totalItems() }}</span>
+    <span class="badge">{{ giCart.totalQuantity() }}</span>
   </div>
 </div>


### PR DESCRIPTION
This Github issue is synchronized with Zendesk,

**Zendesk ticket ID:** [113](https://goincremental.zendesk.com/agent/#/tickets/113)
**Priority:** normal
**Zendesk assignee:** Support/David Bochenski


**Original ticket content:**

This is what amazon do.
