### PR TITLE
Cart is being stored as json string within json string

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Best served as a component of [gi](https://github.com/goincremental/gi) but if y
 v0.6.1
 - Summary directive now displays total quantity of items, not just number of distinct items
 - Fixes issue where register user was called too frequently in the checkout process
+- Fixes issue where cart was JSON stringified twice in local storage
 
 v0.6.0
 - added giPaymentThanks directive allowing the application to inject their own thankyou directive.

--- a/client/services/cart.coffee
+++ b/client/services/cart.coffee
@@ -57,7 +57,7 @@ angular.module('gi.commerce').provider 'giCart', () ->
       return
 
     save = () ->
-      store.set 'cart', JSON.stringify(cart)
+      store.set 'cart', cart
 
     calculateTaxRate = () ->
       countryCode = cart.country.code


### PR DESCRIPTION
This Github issue is synchronized with Zendesk,

**Zendesk ticket ID:** [112](https://goincremental.zendesk.com/agent/#/tickets/112)
**Priority:** normal
**Zendesk assignee:** Support/David Bochenski


**Original ticket content:**

The angular local storage service already stringifies the object, so no need to do this in giCart save.
