### PR TITLE
Validate credit card length

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Best served as a component of [gi](https://github.com/goincremental/gi) but if y
 - Client side components: `bower install gi-commerce`
 
 ##Release Notes
+
+v0.6.6
+- fixes issue with credit card validation where it would eagerly validate invalid numbers (especially visa)
+
 v0.6.5
 - resolve tab ordering on payment forms
 - provide feedback when processing payment

--- a/client/directives/cardValidation.coffee
+++ b/client/directives/cardValidation.coffee
@@ -33,11 +33,12 @@ angular.module('gi.commerce').directive 'giCcNum'
         card.parse number
 
       ngModelController.$validators.giCcNumber = (number) ->
-        card.isValid number
+        res = card.isValid number
+        res? and res
 
       ngModelController.$validators.giCcNumberType = (number) ->
-        card.isValid number, $parse(attrs.giCcType)($scope)
-
+        res = card.isValid number, $parse(attrs.giCcType)($scope)
+        res? and res
 
     #return the linking function
     linkFn

--- a/client/services/card.coffee
+++ b/client/services/card.coffee
@@ -27,7 +27,7 @@ angular.module('gi.commerce').factory 'giCard'
       if not number?
         return false
       len = number.length
-      if len < 15
+      if len < 13
         return false
 
       mul = 0


### PR DESCRIPTION
This Github issue is synchronized with Zendesk,

**Zendesk ticket ID:** [106](https://goincremental.zendesk.com/agent/#/tickets/106)
**Priority:** normal
**Zendesk assignee:** Support/David Bochenski


**Original ticket content:**

The length should be either 16 or 17 characters.  Ideally this would alter with type as we've done for CVC number
