### PR TITLE
Payment Failed message

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Best served as a component of [gi](https://github.com/goincremental/gi) but if y
 ##Release Notes
 
 v0.6.6
+- Display detailed error messages if the stripe charge fails
 - Capture a phone number for courier when items require shipping.
 - Tab ordering now handles situation where there are multiple address forms visible on a page, and also ensures we autofocus on the first form in customer info capture
 - Fixes issue with credit card validation where it would eagerly validate invalid numbers (especially visa)

--- a/client/services/payment.coffee
+++ b/client/services/payment.coffee
@@ -32,8 +32,11 @@ angular.module('gi.commerce').factory 'giPayment'
       $http.post('/api/checkout', chargeRequest)
       .success () ->
         deferred.resolve 'payment completed'
-      .error () ->
-        deferred.reject 'payment not completed'
+      .error (data) ->
+        msg = 'payment not completed'
+        if data.message?
+          msg = data.message
+        deferred.reject msg
 
       deferred.promise
 ]


### PR DESCRIPTION
This Github issue is synchronized with Zendesk,

**Zendesk ticket ID:** [107](https://goincremental.zendesk.com/agent/#/tickets/107)
**Priority:** normal
**Zendesk assignee:** Support/David Bochenski


**Original ticket content:**

If the payment fails and we know its because of a card error.  Change the message displayed to 'Please check your card details and try again'
