### PR TITLE
Internationalisation for State/County/Region

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Best served as a component of [gi](https://github.com/goincremental/gi) but if y
 - Client side components: `bower install gi-commerce`
 
 ##Release Notes
+v0.6.7
+- Use giI18n for State / County / Region text of address forms
 
 v0.6.6
 - Display detailed error messages if the stripe charge fails

--- a/client/directives/addressFormFields.coffee
+++ b/client/directives/addressFormFields.coffee
@@ -1,6 +1,6 @@
 angular.module('gi.commerce').directive 'giAddressFormFields'
-, ['giCart'
-, (Cart) ->
+, ['giCart', 'giI18n'
+, (Cart, I18n) ->
   restrict : 'E'
   templateUrl: 'gi.commerce.addressFormFields.html'
   scope:
@@ -14,6 +14,10 @@ angular.module('gi.commerce').directive 'giAddressFormFields'
 
   link: ($scope, elem, attrs) ->
     $scope.cart = Cart
+
+    $scope.getStateMessage = () ->
+      I18n.getCapitalisedMessage('gi-postal-area')
+
     if not $scope.item?
       $scope.item = {}
 

--- a/client/index.coffee
+++ b/client/index.coffee
@@ -1,5 +1,19 @@
 angular.module('gi.commerce', ['gi.util', 'gi.security'])
-.value('version', '0.2.0')
+.value('version', '0.6.7-dev')
+.config(['giI18nProvider', (I18nProvider) ->
+  messages =
+    US: [
+      {key: 'gi-postal-area', value: 'state'}
+    ]
+    GB: [
+      {key: 'gi-postal-area', value: 'county'}
+    ]
+    ROW: [
+      {key: 'gi-postal-area', value: 'region'}
+    ]
+  angular.forEach messages, (messages, countryCode) ->
+    I18nProvider.setMessagesForCountry messages, countryCode
+])
 .run ['$rootScope', 'giCart','giCartItem', 'giLocalStorage'
 , ($rootScope, giCart, giCartItem, store) ->
   $rootScope.$on 'giCart:change', () ->

--- a/client/views/gi.commerce.addressFormFields.html
+++ b/client/views/gi.commerce.addressFormFields.html
@@ -52,7 +52,7 @@
      ng-class="{
        'has-error': isPropertyValidationError('{{prefix}}-state'),
        'has-success': isPropertyValidationSuccess('{{prefix}}-state')}">
-  <label class="control-label">State:</label>
+  <label class="control-label">{{getStateMessage()}}:</label>
   <input type="text"
          class="form-control"
          name="{{prefix}}-state"


### PR DESCRIPTION
This Github issue is synchronized with Zendesk,

**Zendesk ticket ID:** [103](https://goincremental.zendesk.com/agent/#/tickets/103)
**Priority:** normal
**Zendesk assignee:** Support/David Bochenski


**Original ticket content:**

In US - addresses should say 'State'.  UK County, everywhere else Region
